### PR TITLE
Fix for failure when dev environment is on non-C: drive

### DIFF
--- a/prepareCurl.bat
+++ b/prepareCurl.bat
@@ -206,7 +206,7 @@ CALL %msVS_Path%\VC\Auxiliary\Build\vcvarsall.bat %currentBuildCompilerOption%
 IF !ERRORLEVEL! EQU 1 CALL:error 1 "Could not setup %~1 compiler"
 
 REM vcvarsall.bat moves to users folder so cs is necessary
-CD !folder!
+CD /D !folder!
 IF %logLevel% GEQ %trace% (
 	nmake /f Makefile.vc mode=dll VC=%msVS_Version% DEBUG=yes MACHINE=%~1
 ) ELSE (


### PR DESCRIPTION
When running vcvarsall.bat during compilation, the current directory switches to the Users directory and has to be changed back to the original winbuild folder. However, if ortclib is being built on a drive that is not C:, the `CD` command will fail. This pull request adds the `/D` flag to allow for cross-drive directory changes.